### PR TITLE
広告検出を言語非依存化

### DIFF
--- a/XDeck/WebViewConfigurations.swift
+++ b/XDeck/WebViewConfigurations.swift
@@ -178,16 +178,13 @@ struct WebViewConfigurations {
 
     static let hideAds: String = """
         function hideAds(parent) {
-          let xpath =
-            '//div[@data-testid="cellInnerDiv" and descendant::span[text()="Ad"]]';
-          let elements = getElementsByXPath(xpath, parent);
-          if (elements.length > 0) {
-            // console.log(`hide ${elements.length} ads`)
-            elements.forEach((div) => {
-              // console.log(div.textContent);
-              div.style.display = "none";
-            });
-          }
+          const root = parent || document;
+          const cells = root.querySelectorAll('div[data-testid="cellInnerDiv"]');
+          cells.forEach((cell) => {
+            if (cell.querySelector('div[data-testid="placementTracking"]')) {
+              cell.style.display = "none";
+            }
+          });
         }
 
         if (!window.hideAdsMutationObserver) {
@@ -219,11 +216,11 @@ struct WebViewConfigurations {
             window.hideAdsMutationObserver = null;
           }
 
-          let xpath =
-            '//div[@data-testid="cellInnerDiv" and descendant::span[text()="Ad"]]';
-          let elements = getElementsByXPath(xpath);
-          elements.forEach((div) => {
-            div.style.display = "flex";
+          const cells = document.querySelectorAll('div[data-testid="cellInnerDiv"]');
+          cells.forEach((cell) => {
+            if (cell.querySelector('div[data-testid="placementTracking"]')) {
+              cell.style.display = "flex";
+            }
           });
         })();
     """


### PR DESCRIPTION
## Summary
- 広告検出ロジックを `text()="Ad"` のXPath判定から `data-testid="placementTracking"` のquerySelector判定に変更
- 日本語UI（"広告"表示）でも広告が正しく非表示になるように修正

## Test plan
- [ ] 英語UIで広告が非表示になることを確認
- [ ] 日本語UIで広告が非表示になることを確認
- [ ] 広告ブロック無効化時に広告が再表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)