### PR TITLE
WebView: リダイレクト時のリロードループを修正

### DIFF
--- a/XDeck/View/LoginView.swift
+++ b/XDeck/View/LoginView.swift
@@ -14,7 +14,7 @@ struct LoginView: View {
                 isLoading: $isLoading, url: $url, alertMessage: $alertMessage,
                 messageFromWebView: $loginViewMessage,
                 scriptExecutionRequest: $scriptExecutionRequest,
-                configuration: WebViewConfigurations.makeConfiguration(onLoadScripts: [.findUserName, .findThemeColor]))
+                configuration: WebViewConfigurations.makeConfiguration(onLoadScripts: [.global, .findUserName, .findThemeColor]))
         }
         .padding()
         .onChange(of: alertMessage) { message in

--- a/XDeck/View/LoginView.swift
+++ b/XDeck/View/LoginView.swift
@@ -14,7 +14,7 @@ struct LoginView: View {
                 isLoading: $isLoading, url: $url, alertMessage: $alertMessage,
                 messageFromWebView: $loginViewMessage,
                 scriptExecutionRequest: $scriptExecutionRequest,
-                configuration: WebViewConfigurations.makeConfiguration(onLoadScripts: [.global, .findUserName, .findThemeColor]))
+                configuration: WebViewConfigurations.makeConfiguration(onLoadScripts: [.findUserName, .findThemeColor]))
         }
         .padding()
         .onChange(of: alertMessage) { message in

--- a/XDeck/View/WebView.swift
+++ b/XDeck/View/WebView.swift
@@ -24,7 +24,7 @@ struct WebView: NSViewRepresentable {
             webView = WKWebView()
         }
         // Pretend Safari because 𝕏 bans the user agent of WebView
-        webView.customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1.2 Safari/605.1.15"
+        webView.customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Safari/605.1.15"
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
         let request = URLRequest(url: url)
@@ -33,7 +33,7 @@ struct WebView: NSViewRepresentable {
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
-        if let url = webView.url, url != context.coordinator.lastUrl {
+        if url != context.coordinator.lastUrl {
             let request = URLRequest(url: url)
             context.coordinator.lastUrl = url
             webView.load(request)


### PR DESCRIPTION
## Summary
- `updateNSView` でリダイレクト後のURLではなく指定URLと比較してリロードループが発生する問題を修正
- LoginViewに `.global` スクリプトを追加
- User-AgentをSafari 18.3に更新

## Test plan
- [ ] ログイン後にリロードループが発生しないことを確認
- [ ] 各カラムが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)