### PR TITLE
Fix reload loop caused by ⌘R refresh

### DIFF
--- a/XDeck/View/WebView.swift
+++ b/XDeck/View/WebView.swift
@@ -41,7 +41,7 @@ struct WebView: NSViewRepresentable {
         if refreshSwitch != context.coordinator.refreshSwitch {
             let request = URLRequest(url: url)
             webView.load(request)
-            context.coordinator.refreshSwitch = !refreshSwitch
+            context.coordinator.refreshSwitch = refreshSwitch
         } else if let script = scriptExecutionRequest {
             webView.evaluateJavaScript(script)
             DispatchQueue.main.async {


### PR DESCRIPTION
## Summary
- Fixed `refreshSwitch` coordinator sync using `!refreshSwitch` instead of `refreshSwitch`, which prevented the state from ever synchronizing
- Each reload triggered `isLoading` changes → SwiftUI re-render → `updateNSView` → mismatch detected → reload again (infinite loop)
- This caused X.com to get stuck on its splash screen and eventually corrupted session state

## Test plan
- [x] Press ⌘R to refresh and verify columns reload once without getting stuck on splash
- [x] Verify multiple ⌘R presses work correctly
- [x] Verify app restart after refresh works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)