### PR TITLE
Fix file picker for media attachments

### DIFF
--- a/XDeck/View/WebView.swift
+++ b/XDeck/View/WebView.swift
@@ -97,6 +97,20 @@ class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessage
         print("🚨️ \(message)")
     }
 
+    func webView(_ webView: WKWebView, runOpenPanelWith parameters: WKOpenPanelParameters, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping ([URL]?) -> Void) {
+        let openPanel = NSOpenPanel()
+        openPanel.canChooseFiles = true
+        openPanel.canChooseDirectories = false
+        openPanel.allowsMultipleSelection = parameters.allowsMultipleSelection
+        openPanel.begin { response in
+            if response == .OK {
+                completionHandler(openPanel.urls)
+            } else {
+                completionHandler(nil)
+            }
+        }
+    }
+
     // MARK: WKScriptMessageHandler
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard message.name == WebViewConfigurations.handlerName else { return }


### PR DESCRIPTION
## Summary
- Implement `WKUIDelegate.runOpenPanelWith` in the WebView coordinator to present `NSOpenPanel` when X.com's file input is triggered
- Supports multiple file selection when allowed by the web page
- Fixes the issue where clicking the media attach button did nothing

Closes #5

## Test plan
- [x] Open XDeck and compose a new post
- [x] Click the media attach button (image/video icon)
- [x] Verify the file picker dialog opens
- [x] Select a file and confirm it attaches to the post

🤖 Generated with [Claude Code](https://claude.com/claude-code)