### PR TITLE
Expand column to full width for media preview

### DIFF
--- a/XDeck/View/ContentView.swift
+++ b/XDeck/View/ContentView.swift
@@ -19,6 +19,7 @@ struct ContentView: View {
 
     @State var webViewMessage: String? = nil
     @State var loginViewMessage: String? = nil
+    @State var expandedColumnIndex: Int? = nil
 
     @State var homeUrl: URL = URL(string: "https://x.com/home")!
     @State var notificationsUrl: URL = URL(string: "https://x.com/notifications")!
@@ -49,14 +50,14 @@ struct ContentView: View {
 
     @ViewBuilder
     private func makeColumn(
-        column: AppConfig.Column, isLeftMostXColumn: Bool, profileUrl: Binding<URL?>, columnWidth: CGFloat
+        column: AppConfig.Column, columnIndex: Int, isLeftMostXColumn: Bool, profileUrl: Binding<URL?>, columnWidth: CGFloat
     )
         -> some View
     {
         let width = isLeftMostXColumn ? columnWidth + Self.sideHeaderWidth : columnWidth
 
         let baseConfiguration: [WebViewConfigurations.OnLoadScript] = {
-            var scripts: [WebViewConfigurations.OnLoadScript] = [.global]
+            var scripts: [WebViewConfigurations.OnLoadScript] = [.global, .detectMediaOverlay(columnIndex: columnIndex)]
             if isLeftMostXColumn {
                 scripts.append(.findThemeColor)
             } else if column.isXColumn {
@@ -201,12 +202,19 @@ struct ContentView: View {
                                         ForEach(appConfig.columns.indices, id: \.self) { index in
                                             let isLeftMostXColumn =
                                                 index == (appConfig.columns.firstIndex { $0.isXColumn } ?? -1)
+                                            let isExpanded = expandedColumnIndex == index
+                                            let isHidden = expandedColumnIndex != nil && !isExpanded
+                                            let effectiveWidth: CGFloat = isExpanded
+                                                ? (isLeftMostXColumn ? geometry.size.width - Self.sideHeaderWidth : geometry.size.width)
+                                                : dynamicColumnWidth
                                             makeColumn(
                                                 column: appConfig.columns[index],
+                                                columnIndex: index,
                                                 isLeftMostXColumn: isLeftMostXColumn,
                                                 profileUrl: $profileUrl,
-                                                columnWidth: dynamicColumnWidth
+                                                columnWidth: isHidden ? 0 : effectiveWidth
                                             )
+                                            .opacity(isHidden ? 0 : 1)
                                         }
                                     }
                                 }
@@ -288,6 +296,7 @@ struct ContentView: View {
                                 loginViewMessage: $loginViewMessage
                             )
                         }
+
                     }
                     .background(backgroundColor)
                     .colorScheme(isDarkMode ? .dark : .light)
@@ -305,6 +314,8 @@ struct ContentView: View {
                                 let color = Color(hex: message.body)
                                 backgroundColor = color
                                 isDarkMode = color != Color.white
+                            case .mediaOverlay:
+                                break
                             }
                         }
                     }
@@ -321,6 +332,12 @@ struct ContentView: View {
                                 let color = Color(hex: message.body)
                                 backgroundColor = color
                                 isDarkMode = color != Color.white
+                            case .mediaOverlay:
+                                if message.body == "close" {
+                                    expandedColumnIndex = nil
+                                } else if let index = Int(message.body) {
+                                    expandedColumnIndex = index
+                                }
                             }
                         }
                     }

--- a/XDeck/WebViewConfigurations.swift
+++ b/XDeck/WebViewConfigurations.swift
@@ -11,6 +11,7 @@ struct WebViewConfigurations {
         case clickFollowingTab
         case hideSideHeader
         case hideAds
+        case detectMediaOverlay(columnIndex: Int)
 
         var scriptContent: String {
             switch self {
@@ -22,6 +23,7 @@ struct WebViewConfigurations {
             case .clickFollowingTab: return WebViewConfigurations.clickFollowingTab
             case .hideSideHeader: return WebViewConfigurations.hideSideHeader
             case .hideAds: return WebViewConfigurations.hideAds
+            case .detectMediaOverlay(let columnIndex): return WebViewConfigurations.detectMediaOverlay(columnIndex: columnIndex)
             }
         }
 
@@ -29,7 +31,7 @@ struct WebViewConfigurations {
             switch self {
             case .findUserName, .findThemeColor, .clickForYouTab, .clickFollowingTab, .hideSideHeader, .hidePostArea, .hideAds:
                 return true
-            case .global:
+            case .global, .detectMediaOverlay:
                 return false
             }
         }
@@ -219,4 +221,31 @@ struct WebViewConfigurations {
           });
         })();
     """
+
+    private static func detectMediaOverlay(columnIndex: Int) -> String {
+        return """
+            (function() {
+                var mediaExpanded = false;
+                const originalPushState = history.pushState;
+                history.pushState = function() {
+                    originalPushState.apply(this, arguments);
+                    const url = window.location.href;
+                    if (!mediaExpanded && /\\/(photo|video)\\/\\d+/.test(url)) {
+                        mediaExpanded = true;
+                        const message = JSON.stringify({ type: "mediaOverlay", body: String(\(columnIndex)) });
+                        webkit.messageHandlers.\(Self.handlerName).postMessage(message);
+                    }
+                };
+                window.addEventListener('popstate', function() {
+                    const url = window.location.href;
+                    if (mediaExpanded && !/\\/(photo|video)\\/\\d+/.test(url)) {
+                        mediaExpanded = false;
+                        const message = JSON.stringify({ type: "mediaOverlay", body: "close" });
+                        webkit.messageHandlers.\(Self.handlerName).postMessage(message);
+                    }
+                });
+            })();
+        """
+    }
 }
+

--- a/XDeck/WebViewMessage.swift
+++ b/XDeck/WebViewMessage.swift
@@ -7,5 +7,6 @@ struct WebViewMessage: Decodable {
     enum MessageType: String, Decodable {
         case userName
         case themeColor
+        case mediaOverlay
     }
 }


### PR DESCRIPTION
## Summary
- Detect when X.com's media lightbox opens by hooking `history.pushState` for `/photo/` and `/video/` URLs
- Expand the active column to full window width and hide other columns (width 0, opacity 0) so the lightbox fills the screen
- Restore original multi-column layout when the lightbox is closed via `popstate`
- No page re-fetch — the existing WKWebView is reused and simply resized

Closes #6

## Test plan
- [x] Click on an image in a tweet — column expands to full width, lightbox fills the window
- [x] Close the lightbox (Escape or X button) — columns restore to original layout
- [x] Click on a video — same expansion behavior
- [x] Multi-photo tweets — navigating between photos stays expanded
- [x] Other columns remain functional after restoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)